### PR TITLE
chore(node): upgrade to Node.js 24 LTS (Krypton)

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ inputs:
   node-version:
     description: 'Node version to setup with'
     required: false
-    default: '22'
+    default: '24'
   node-auth-token:
     description: 'Token to use for NPM authentication'
     required: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node
               uses: ./.github/actions/setup-node
               with:
-                  node-version: 22
+                  node-version: 24
                   node-auth-token: ${{ secrets.CI_TOKEN }}
 
             - name: Create Release

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,7 +17,7 @@ jobs:
 
             - uses: ./.github/actions/setup-node
               with:
-                node-version: 22
+                node-version: 24
                 node-auth-token: ${{ secrets.CI_TOKEN }}
 
             - name: Type Check
@@ -52,7 +52,7 @@ jobs:
 
             - uses: ./.github/actions/setup-node
               with:
-                node-version: 22
+                node-version: 24
                 node-auth-token: ${{ secrets.CI_TOKEN }}
 
             - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 # Install dependencies almost always needed
 RUN apk --no-cache add python3 make g++ && ln -sf python3 /usr/bin/python

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Backend service containing App-Subscription, User, Account and related concerns.
 
 ## Requirements
 
-- NodeJS 22.x
+- NodeJS 24.x
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "url": "https://github.com/ernestdolog/subscription-management-service.git/issues"
     },
     "homepage": "https://github.com/ernestdolog/subscription-management-service.git#readme",
+    "engines": {
+        "node": ">=24.0.0"
+    },
     "devDependencies": {
         "@commitlint/cli": "^19.7.1",
         "@commitlint/config-conventional": "^19.7.1",


### PR DESCRIPTION
Upgrade entire project to use Node.js 24 LTS:
- Add engines field to package.json requiring Node.js >=24.0.0
- Update Dockerfile from node:22-alpine to node:24-alpine
- Update GitHub Actions setup-node default from 22 to 24
- Update CI/CD workflow node-version references to 24
- Update README requirements to NodeJS 24.x

Node.js 24 LTS (Krypton) is the latest LTS release, maintained until April 2028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)